### PR TITLE
Issue 5/load wards from notebook

### DIFF
--- a/data/etl_templates/ons_ward_to_lad_template.json
+++ b/data/etl_templates/ons_ward_to_lad_template.json
@@ -8,10 +8,6 @@
     "WD25NMW": "welsh_ward_name",
     "LAD25CD": "local_authority_code",
     "LAD25NM": "local_authority_name",
-    "LAD25NMW": "welsh_local_authority_name",
-    "ObjectId": "ons_internal_id"
-  },
-  "column_type_overrides": {
-    "ons_internal_id": "TINYINT"
+    "LAD25NMW": "welsh_local_authority_name"
   }
 }

--- a/notebooks/03_ingest_wards_from_ons_csv.ipynb
+++ b/notebooks/03_ingest_wards_from_ons_csv.ipynb
@@ -1,0 +1,56 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "023b72b6-9244-4096-91a8-07f1ccd13280",
+   "metadata": {},
+   "source": [
+    "# Load ward data using Python scripts\n",
+    "\n",
+    "This uses extract and load methods in the `src/etl/csv.py` file to load ONS Ward to Local Authority District data into DuckDB.\n",
+    "\n",
+    "The `load_from_template` is a generic method that loads data from a CSV source based on a JSON template"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "467c7199-a6d2-4343-acac-2ad1e5b513a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from etl.csv import load_from_template"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b0661445-e291-4929-add5-929d6b4562d8",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/03_ingest_wards_from_ons_csv.ipynb
+++ b/notebooks/03_ingest_wards_from_ons_csv.ipynb
@@ -9,27 +9,194 @@
     "\n",
     "This uses extract and load methods in the `src/etl/csv.py` file to load ONS Ward to Local Authority District data into DuckDB.\n",
     "\n",
-    "The `load_from_template` is a generic method that loads data from a CSV source based on a JSON template"
+    "## Background\n",
+    "Some of the Arts Council data (e.g. grants) uses Local Authority (LA) names whilst other data reports at the ward level.\n",
+    "\n",
+    "Given this, it'd  be useful to get a ward to local authority mapping from an authoritative source. This notebook does that and also demos how to use the generic extract and load methods in the Python scripts in this project.\n",
+    "\n",
+    "## Approach\n",
+    "This notebook uses the Python scripts in the `src` folder of the project. There are instructions at the bottom of the `readme.md` of how to create a virtual environment and install the project so that it can be imported as below. They are copied here but check the `readme` in case they have been updated since the notebook\n",
+    "\n",
+    "### (Copied from readme.md) Installation\n",
+    "\n",
+    "If you haven't set up a `venv` with the Python scripts in (see below) *you'll need to do this before you run this notebook*\n",
+    "\n",
+    "* Requires Python 3.12 and pip\n",
+    "* Dependencies and other stuff are defined in the `pyproject.toml`\n",
+    "* From the `brighton_creatives` directory:\n",
+    "  * `python -m venv venv`\n",
+    "  * `source venv/bin/activate` (`.\\venv\\Scripts\\activate.bat` from Windows cmd)\n",
+    "  * `pip install -e .[dev]`\n",
+    "   \n",
+    "\n",
+    "* Now relaunch Jupyter Notebook from Terminal (or Windows cmd) from the `venv` you just activated. This will mean the project (including the ETL scripts) have been loaded\n",
+    "\n",
+    "`jupyter notebook`\n"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "467c7199-a6d2-4343-acac-2ad1e5b513a0",
+   "cell_type": "markdown",
+   "id": "360c1210-de1b-43bd-a054-a5973e5a21b6",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "from pathlib import Path\n",
-    "from etl.csv import load_from_template"
+    "### The loader\n",
+    "The `load_from_template` method is a generic method that extracts data from simple CSVs and loads into DuckDb. It uses a JSON template that defines the table name, new column names, and any non-`VARCHAR` columns for the table."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b0661445-e291-4929-add5-929d6b4562d8",
+   "id": "467c7199-a6d2-4343-acac-2ad1e5b513a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from etl.csv import load_from_template\n",
+    "import duckdb\n",
+    "import pandas as pd\n",
+    "from pathlib import Path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a358ae0-dd81-4ddd-b284-ab7b17459837",
+   "metadata": {},
+   "source": [
+    "### Paths to the source data and templates\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "553f3b24-febc-4628-9a7b-410ae9b067ae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATA_PATH = '../data/'\n",
+    "PATH_TO_DB = DATA_PATH+'creatives.duckdb'\n",
+    "PATH_TO_ONS_WARD_DATA = DATA_PATH+'csv/ons/ward_to_local_authority_may_2025.csv'\n",
+    "PATH_TO_ONS_WARD_TEMPLATE = DATA_PATH+'etl_templates/ons_ward_to_lad_template.json'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff48f1cc-b11e-4a7d-9445-9f48f0188f6b",
+   "metadata": {},
+   "source": [
+    "### This is what the Ward to Local Authority Mapping data looks like ... "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb70f98d-c703-420c-a913-2c200bad6637",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_ward = pd.read_csv(PATH_TO_ONS_WARD_DATA, header=0, encoding='utf-8')\n",
+    "display(df_ward.head())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef410055-5dc0-401e-ac63-6c1e12c399c9",
+   "metadata": {},
+   "source": [
+    "The `WD25CD` and `LAD25CD` are the ONS unique identifiers for the particular Ward and Local Authority.\n",
+    "\n",
+    "The fields that end in `W` e.g. `WD25NMW` are Welsh names where appropriate, for example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "413296d2-ea92-42e7-aa83-2f0a8740c388",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(df_ward[df_ward['WD25NM'] == 'Sketty'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4629d2cd-2b8a-447a-89eb-69b07612956c",
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29904985-af71-45ad-a715-7a8466628d09",
+   "metadata": {},
+   "source": [
+    "### The JSON templates are used to map source columns to target (db columns) and to define the table name ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "84531056-095a-4814-b4f3-37cbd45f9683",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!head -n30 ../data/etl_templates/ons_ward_to_lad_template.json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ea5136d-09ad-4ed8-b88b-ab66d436bb28",
+   "metadata": {},
+   "source": [
+    "\n",
+    "The JSON also supports:\n",
+    "  *  `header_line` - which is a zero-indexed row where the column names are (defaults to 0)\n",
+    "  *  `skip_rows` - if there are non-header rows that have to be skipped\n",
+    "  *  `column_mappings` - if there are non-`VARCHAR columns`\n",
+    "\n",
+    "For example:\n",
+    "```json\n",
+    "{\n",
+    "  \"name\": \"ons-ward-to-la\",\n",
+    "  \"target_table\": \"ward_to_lad\",\n",
+    "  \"column_mappings\": {\n",
+    "    \"WD25CD\": \"ward_code\",\n",
+    "    \"WD25NM\": \"ward_name\",\n",
+    "    \"WD25NMW\": \"welsh_ward_name\",\n",
+    "    \"LAD25CD\": \"local_authority_code\",\n",
+    "    \"LAD25NM\": \"local_authority_name\",\n",
+    "    \"LAD25NMW\": \"welsh_local_authority_name\",\n",
+    "    \"ObjectId\": \"ons_internal_id\"\n",
+    "  },\n",
+    "  \"column_type_overrides\": {\n",
+    "    \"ons_internal_id\": \"TINYINT\"\n",
+    "  }\n",
+    "}\n",
+    "\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c8a7fb0-a08e-4559-a6c9-2752b72729e4",
+   "metadata": {},
+   "source": [
+    "## Loading the data\n",
+    "This is as simple as passing a db connection, the filepath of the source data, and the filepath of the template to `load_from_template`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a0105aa-17d7-48cb-a240-adf30237c687",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with duckdb.connect(database=PATH_TO_DB, read_only=False) as con:\n",
+    "    con.execute(\"DROP TABLE ward_to_lad\")\n",
+    "    load_from_template(con, PATH_TO_ONS_WARD_DATA, PATH_TO_ONS_WARD_TEMPLATE)\n",
+    "    display(con.execute(\"SELECT * FROM ward_to_lad LIMIT 20\").df())\n",
+    "    display(con.execute(\"SELECT * FROM ward_to_lad WHERE welsh_ward_name = 'Sgeti'\").df())\n"
+   ]
   }
  ],
  "metadata": {
@@ -48,7 +215,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brighton-creatives"
-version = "0.2.0"
+version = "0.3.0"
 description = "etl pipelines and tools for Brighton Creatives project"
 authors = [{ name = "sih", email = "sid@datasoc.ltd" }]
 readme = "readme.md"

--- a/readme.md
+++ b/readme.md
@@ -145,6 +145,7 @@ based on a JSON template. A "basic" CSV file is one that has a header row
 {
   "name": "ons-ward-to-la",
   "target_table": "ward_to_lad",
+  "unique_key": "ward_code",
   "column_mappings": {
     "WD25CD": "ward_code",
     "WD25NM": "ward_name",

--- a/src/etl/csv.py
+++ b/src/etl/csv.py
@@ -66,7 +66,12 @@ def load_from_template(
     )
 
     _load_df_to_duck(
-        db_connection, df, target_table, unique_key, column_mappings, column_type_overrides
+        db_connection,
+        df,
+        target_table,
+        unique_key,
+        column_mappings,
+        column_type_overrides,
     )
 
     return target_table
@@ -100,7 +105,9 @@ def _load_template(json_path: str) -> dict:
     return template
 
 
-def _load_df_to_duck(conn, df, target_table, unique_key, column_mappings, column_type_overrides):
+def _load_df_to_duck(
+    conn, df, target_table, unique_key, column_mappings, column_type_overrides
+):
     default_type = "VARCHAR"
     logger.debug(f"df columns {df.columns}")
     source_col_names = (
@@ -144,6 +151,8 @@ def _load_df_to_duck(conn, df, target_table, unique_key, column_mappings, column
     if not unique_key:
         conn.execute(f"INSERT INTO {target_table} SELECT * FROM temp_table")
     else:
-        conn.execute(f"INSERT INTO {target_table} SELECT * FROM temp_table ON CONFLICT DO NOTHING")
+        conn.execute(
+            f"INSERT INTO {target_table} SELECT * FROM temp_table ON CONFLICT DO NOTHING"
+        )
     # clean up
     conn.unregister("temp_table")

--- a/src/etl/csv.py
+++ b/src/etl/csv.py
@@ -43,6 +43,9 @@ def load_from_template(
     skip_rows = template.get("skip_rows", 0)
     logger.debug(f"Will skip {skip_rows} lines")
 
+    unique_key = template.get("unique_key", None)
+    logger.debug(f"{unique_key} is the unique key")
+
     encoding = template.get("encoding", "utf-8")
     logger.debug(f"File encoding is {encoding}")
 
@@ -63,7 +66,7 @@ def load_from_template(
     )
 
     _load_df_to_duck(
-        db_connection, df, target_table, column_mappings, column_type_overrides
+        db_connection, df, target_table, unique_key, column_mappings, column_type_overrides
     )
 
     return target_table
@@ -97,7 +100,7 @@ def _load_template(json_path: str) -> dict:
     return template
 
 
-def _load_df_to_duck(conn, df, target_table, column_mappings, column_type_overrides):
+def _load_df_to_duck(conn, df, target_table, unique_key, column_mappings, column_type_overrides):
     default_type = "VARCHAR"
     logger.debug(f"df columns {df.columns}")
     source_col_names = (
@@ -116,17 +119,31 @@ def _load_df_to_duck(conn, df, target_table, column_mappings, column_type_overri
     ]
     logger.debug(f"Column defs are: {col_defs}")
 
+    unique_constraint = f"CONSTRAINT uk_{target_table} UNIQUE ({unique_key})"
+
     # create target table in duck
-    create_table_sql = f"""
-    CREATE TABLE IF NOT EXISTS {target_table} (
-        {", ".join(col_defs)}
-    )
-    """
+    if not unique_key:
+        create_table_sql = f"""
+        CREATE TABLE IF NOT EXISTS {target_table} (
+            {", ".join(col_defs)}
+        )
+        """
+    else:
+        create_table_sql = f"""
+        CREATE TABLE IF NOT EXISTS {target_table} (
+            {", ".join(col_defs)},
+            {unique_constraint}
+        )
+        """
+    logger.debug(f"Create statement is {create_table_sql}")
     conn.execute(create_table_sql)
 
     # register temp table with the cleaned df
     conn.register("temp_table", df_clean)
     # insert from temp table into target table
-    conn.execute(f"INSERT INTO {target_table} SELECT * FROM temp_table")
+    if not unique_key:
+        conn.execute(f"INSERT INTO {target_table} SELECT * FROM temp_table")
+    else:
+        conn.execute(f"INSERT INTO {target_table} SELECT * FROM temp_table ON CONFLICT DO NOTHING")
     # clean up
     conn.unregister("temp_table")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 
 def pytest_configure():
     # change me to alter the logging level across tests
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.DEBUG)
 
 
 class TestDBConnection:

--- a/tests/etl/test_csv.py
+++ b/tests/etl/test_csv.py
@@ -91,4 +91,4 @@ def test_load_from_template_valid_template(testdb_connection):
     assert ward_data[4] == "Hartlepool"
     assert ward_data[5] is None
     assert ward_data[6] == 1
-    assert type(ward_data[6]) == int
+    assert isinstance(ward_data[6], int)


### PR DESCRIPTION
closes https://github.com/oh-data-sci/brighton_creatives/issues/5

* Show an example of using the Python scripts to load from a Notebook, `03_ingest_wards_from_ons_csv.ipynb`
* Support `unique_key` so that repeated loads can be idempotent by using `ON CONFLICT DO NOTHING`
* Add Ward to Local Authority template to new template directory in `data/etl_templates`